### PR TITLE
Fixed exception in VAB with Nose cones

### DIFF
--- a/Source/CrossFeedEnabler.cs
+++ b/Source/CrossFeedEnabler.cs
@@ -57,10 +57,13 @@ namespace CrossFeedEnabler
             {
                 if (crossFeedOverride)
                 {
-                    if (!part.parent.fuelLookupTargets.Contains(part))
-                        part.parent.fuelLookupTargets.Add(part);
-                    if (!part.fuelLookupTargets.Contains(part.parent))
-                        part.fuelLookupTargets.Add(part.parent);
+                    if (HighLogic.LoadedSceneIsFlight)
+                    {
+                        if (!part.parent.fuelLookupTargets.Contains(part))
+                            part.parent.fuelLookupTargets.Add(part);
+                        if (!part.fuelLookupTargets.Contains(part.parent))
+                            part.fuelLookupTargets.Add(part.parent)
+                    }
                     Events["ToggleCrossFeed"].guiName = "Crossfeed is On";
                 }
                 else


### PR DESCRIPTION
crossfeed does not need to function in the VAB, but it does cause problem when updated in the VAB
